### PR TITLE
docs: CCH signing analysis, fast mode research, update all notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,15 @@ bun.lockb
 opencode-auth-research/*/node_modules/
 opencode-auth-research/*/dist/
 
+# External cloned repos (too large, clone locally)
+external/HitCC/
+external/claude-code-reverse-engineering/
+external/claude-code-source-code-deobfuscation/
+
+# npm package vendor binaries
+npm-package/*/package/vendor/
+npm-package/*/package/*.wasm
+
 # OS
 .DS_Store
 

--- a/binaries/v2.1.80/API_REQUEST_MAP.md
+++ b/binaries/v2.1.80/API_REQUEST_MAP.md
@@ -1,0 +1,460 @@
+# Claude Code v2.1.80 — API Request Shape & Fingerprinting Map
+
+Reverse-engineered from the native darwin-arm64 Bun binary using [bun-demincer](https://github.com/vicnaum/bun-demincer). 4777 modules extracted, 3074 app code modules identified. Cross-referenced with live traffic via intercept proxy (`ANTHROPIC_BASE_URL` override).
+
+Source files referenced below use bun-demincer module IDs (e.g. `0747.js`).
+
+---
+
+## 1. User-Agent String
+
+```
+claude-cli/<VERSION> (external, <ENTRYPOINT><SDK_SUFFIX><CLIENT_SUFFIX><WORKLOAD_SUFFIX>)
+```
+
+Components:
+- `ENTRYPOINT`: `process.env.CLAUDE_CODE_ENTRYPOINT ?? "cli"` — values: `cli`, `vscode`, `jetbrains`, `agent-sdk`, `sdk-cli`
+- `SDK_SUFFIX`: if `CLAUDE_AGENT_SDK_VERSION` set → `, agent-sdk/<version>`
+- `CLIENT_SUFFIX`: if `CLAUDE_AGENT_SDK_CLIENT_APP` set → `, client-app/<app>`
+- `WORKLOAD_SUFFIX`: if workload set (AsyncLocalStorage) → `, workload/<name>` (e.g. `workload/cron`)
+
+Observed in live traffic with `-p` flag: `claude-cli/2.1.80 (external, sdk-cli)` (not `cli` — the `-p` print mode uses `sdk-cli` entrypoint).
+
+## 2. Default Headers (all requests)
+
+```
+x-app: cli
+User-Agent: claude-cli/2.1.80 (external, <entrypoint>)
+anthropic-version: 2023-06-01
+anthropic-dangerous-direct-browser-access: true
+```
+
+Stainless SDK headers (added by `@anthropic-ai/sdk`):
+```
+x-stainless-arch: arm64
+x-stainless-lang: js
+x-stainless-os: MacOS
+x-stainless-package-version: 0.74.0
+x-stainless-retry-count: 0
+x-stainless-runtime: node
+x-stainless-runtime-version: v24.13.1
+x-stainless-timeout: 600
+```
+
+### Auth-specific headers
+
+**OAuth path**:
+```
+Authorization: Bearer <accessToken>
+anthropic-beta: oauth-2025-04-20  (included in beta list)
+```
+
+**API key path**:
+```
+x-api-key: <apiKey>
+```
+
+## 3. Beta Headers — Complete Logic
+
+Source: module `2018.js` function `FDq()`. All beta string constants defined in `0743.js`.
+
+### Available beta flags (v2.1.80)
+
+| Variable | Beta String | Condition |
+|----------|------------|-----------|
+| `E4T` | `claude-code-20250219` | Always, unless model is haiku |
+| `XP` | `oauth-2025-04-20` | Only for OAuth auth (`a8()`) |
+| `Za` | `context-1m-2025-08-07` | Only when model ID contains `[1m]` suffix |
+| `Ov8` | `interleaved-thinking-2025-05-14` | Unless `DISABLE_INTERLEAVED_THINKING` env; model must support thinking |
+| `zv8` | `redact-thinking-2026-02-12` | firstParty + thinking + `tengu_quiet_hollow` + showThinkingSummaries !== true |
+| `b4T` | `context-management-2025-06-27` | firstParty + (`USE_API_CONTEXT_MANAGEMENT` OR `tengu_marble_anvil`) |
+| `Na` | `structured-outputs-2025-12-15` | Model supports structured outputs + `tengu_tool_pear` flag |
+| `x4T` | `tool-examples-2025-10-29` | firstParty + `tengu_scarf_coffee` flag |
+| `b8q` | `web-search-2025-03-05` | vertex + model supports web search, OR foundry |
+| `sS_` | `prompt-caching-scope-2026-01-05` | Always for firstParty |
+| - | `ANTHROPIC_BETAS` env var | User-provided custom betas, comma-separated |
+
+### Bedrock beta filtering
+
+Source: module `0744.js`, set `I8q`.
+
+Bedrock strips these betas before sending:
+- `interleaved-thinking-2025-05-14`
+- `context-1m-2025-08-07`
+- `tool-search-tool-2025-10-19`
+- `tool-examples-2025-10-29`
+
+### Beta builder pseudocode (clean)
+
+```js
+function buildBetas(modelId) {
+  const betas = []
+  const isHaiku = canonicalize(modelId).includes("haiku")
+  const platform = getPlatform() // "firstParty" | "bedrock" | "vertex" | "foundry"
+  const isFirstParty = platform === "firstParty"
+
+  if (!isHaiku)                        betas.push("claude-code-20250219")
+  if (isOAuth())                       betas.push("oauth-2025-04-20")
+  if (modelId.match(/\[1m\]/i))        betas.push("context-1m-2025-08-07")
+  if (!env.DISABLE_INTERLEAVED_THINKING && supportsThinking(modelId))
+                                       betas.push("interleaved-thinking-2025-05-14")
+  if (isFirstParty && supportsThinking(modelId) && !showThinkingSummaries && flag("tengu_quiet_hollow"))
+                                       betas.push("redact-thinking-2026-02-12")
+  if (isFirstParty && (env.USE_API_CONTEXT_MANAGEMENT || flag("tengu_marble_anvil")))
+                                       betas.push("context-management-2025-06-27")
+  if (supportsStructuredOutputs(modelId) && flag("tengu_tool_pear"))
+                                       betas.push("structured-outputs-2025-12-15")
+  if (isFirstParty && flag("tengu_scarf_coffee"))
+                                       betas.push("tool-examples-2025-10-29")
+  if (platform === "vertex" && supportsWebSearch(modelId))
+                                       betas.push("web-search-2025-03-05")
+  if (platform === "foundry")          betas.push("web-search-2025-03-05")
+  if (isFirstParty)                    betas.push("prompt-caching-scope-2026-01-05")
+  if (env.ANTHROPIC_BETAS)             betas.push(...env.ANTHROPIC_BETAS.split(","))
+
+  return betas
+}
+```
+
+### Critical finding: `context-1m` is OPT-IN, not automatic
+
+The `context-1m-2025-08-07` beta is ONLY added when the model ID contains a `[1m]` suffix (e.g. `claude-opus-4-6[1m]`). It is NOT automatically sent for 4.6 models.
+
+The context window *size* calculation (`jD()` in `2016.js`) does check model capabilities, but the beta *header* is only triggered by the explicit `[1m]` user opt-in.
+
+## 4. Context Window Logic
+
+Source: module `2016.js`.
+
+### `jD(modelId, activeBetas)` — returns context window size
+
+```js
+function getContextWindow(modelId, activeBetas) {
+  if (has1mSuffix(modelId))                      return 1_000_000
+  const modelInfo = getModelInfo(modelId)         // from cached model list
+  if (modelInfo?.max_input_tokens >= 100_000) {
+    if (modelInfo.max_input_tokens > 200_000 && disable1mContext())
+      return 200_000
+    return modelInfo.max_input_tokens
+  }
+  if (activeBetas?.includes("context-1m-2025-08-07") && supports1mContext(modelId))
+    return 1_000_000
+  if (isCoralReefSonnet(modelId))                return 1_000_000
+  return 200_000  // default
+}
+```
+
+### `CAq(modelId)` — which models support 1M context
+
+```js
+function supports1mContext(modelId) {
+  if (env.CLAUDE_CODE_DISABLE_1M_CONTEXT) return false
+  const canonical = canonicalize(modelId)
+  return canonical.includes("claude-sonnet-4") || canonical.includes("opus-4-6")
+}
+```
+
+Models that get 1M: any `claude-sonnet-4*` (4.0, 4.5, 4.6) and `claude-opus-4-6`.
+
+### `UDq(modelId)` — coral_reef_sonnet gate
+
+```js
+function isCoralReefSonnet(modelId) {
+  if (env.CLAUDE_CODE_DISABLE_1M_CONTEXT) return false
+  if (has1mSuffix(modelId)) return false
+  if (!canonicalize(modelId).includes("sonnet-4-6")) return false
+  return clientData("coral_reef_sonnet") === "true"
+}
+```
+
+This is the special Sonnet 4.6 gate that reads from `client_data`. When `coral_reef_sonnet` is `"true"` in the user's client data, Sonnet 4.6 gets 1M context automatically WITHOUT the `[1m]` suffix.
+
+### Output token limits — `Io(modelId)`
+
+| Model Pattern | Default Output | Upper Limit |
+|--------------|---------------|-------------|
+| `opus-4-6` | 64,000 | 128,000 |
+| `sonnet-4-6` | 32,000 | 128,000 |
+| `opus-4-5`, `sonnet-4*`, `haiku-4*` | 32,000 | 64,000 |
+| `opus-4-1`, `opus-4` | 32,000 | 32,000 |
+| `claude-3-opus` | 4,096 | 4,096 |
+| `claude-3-sonnet` | 8,192 | 8,192 |
+| `claude-3-haiku` | 4,096 | 4,096 |
+| `3-5-sonnet`, `3-5-haiku` | 8,192 | 8,192 |
+| `3-7-sonnet` | 32,000 | 64,000 |
+| default | 32,000 | 64,000 |
+
+If the model's info from the API has `max_tokens >= 4096`, that overrides the upper limit.
+
+## 5. `client_data` Endpoint
+
+Source: module `0747.js`.
+
+### Endpoint
+```
+GET <BASE_API_URL>/api/oauth/claude_cli/client_data
+```
+
+### Request
+```
+Authorization: Bearer <accessToken>
+Content-Type: application/json
+User-Agent: claude-cli/2.1.80 (external, cli)
+```
+
+### Prerequisites
+- Must be OAuth subscriber (`a8()`)
+- Must have `user:profile` scope (`Ok()`)
+- Not disabled by `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
+
+### Response
+```json
+{"client_data": {}}
+```
+
+Returns an empty object for standard accounts. Known fields (from code analysis):
+- `coral_reef_sonnet`: `"true"` — enables automatic 1M context for Sonnet 4.6
+
+### Caching
+Cached in `clientDataCache` within local settings. Only refetched when the cache is stale. The `Dv8()` function handles cache persistence:
+
+```js
+async function fetchAndCacheClientData() {
+  const data = await fetchClientData()
+  const cached = getSettings().clientDataCache
+  if (deepEqual(cached?.data, data)) return data  // no change
+  persistSettings(s => ({ ...s, clientDataCache: { data, timestamp: Date.now() } }))
+  return data
+}
+```
+
+### Lookup
+```js
+function getClientDataField(key) {
+  const value = getSettings().clientDataCache?.data?.[key]
+  return typeof value === "string" ? value : null
+}
+```
+
+## 6. Billing / Attribution Header
+
+```
+x-anthropic-billing-header: cc_version=2.1.80.<modelId>; cc_entrypoint=<entrypoint>; cch=00000; cc_workload=<workload>;
+```
+
+Gated by `tengu_attribution_header` (default: `true`) and `CLAUDE_CODE_ATTRIBUTION_HEADER !== "false"`.
+
+Live traffic observation: the billing header is embedded in the **first system prompt block** as plain text, not as an HTTP header:
+```
+system[0].text = "x-anthropic-billing-header: cc_version=2.1.80.a46; cc_entrypoint=sdk-cli; cch=00000;"
+```
+
+### Update: CCH Signing (April 2026)
+
+The `cch=00000` value in npm-distributed builds is a placeholder. The compiled Bun binary contains native Zig code that computes a real hash:
+
+```
+cch = SHA-256(first_user_message_text)[:5]
+version_suffix = SHA-256(BILLING_SALT + sampled_chars + version)[:3]
+BILLING_SALT = "59cf53e54c78"
+sampled_chars = message[4] + message[7] + message[20]  (pad with '0' if short)
+```
+
+Server-side enforcement was added in late March 2026. Invalid cch= values now result in rejection for fast mode access. See `notes/cch-signing-analysis.md` for the full algorithm and references.
+
+## 7. System Prompt Identity Strings
+
+Three valid identity prefixes:
+```
+"You are Claude Code, Anthropic's official CLI for Claude."
+"You are Claude Code, Anthropic's official CLI for Claude, running within the Claude Agent SDK."
+"You are a Claude agent, built on Anthropic's Claude Agent SDK."
+```
+
+Server-side validation checks for one of these prefixes in system prompts for OAuth sessions.
+
+## 8. Model Capability Checks
+
+Source: module `2018.js` helper functions.
+
+### `Sh6(modelId)` — supports interleaved thinking
+```js
+// firstParty: anything NOT claude-3-*
+// bedrock/vertex: claude-opus-4* or claude-sonnet-4*
+```
+
+### `pOK(modelId)` — supports context management
+```js
+// firstParty: NOT claude-3-*
+// bedrock/vertex: claude-opus-4* or claude-sonnet-4* or claude-haiku-4*
+```
+
+### `fK_(modelId)` — supports structured outputs
+```js
+// firstParty or foundry only
+// claude-sonnet-4-6, claude-sonnet-4-5, claude-opus-4-1, claude-opus-4-5, claude-opus-4-6, claude-haiku-4-5
+```
+
+### `mOK(modelId)` — supports web search
+```js
+// claude-opus-4* or claude-sonnet-4* or claude-haiku-4*
+```
+
+## 9. Feature Flags (tengu_* system)
+
+Feature flags are checked via `Tq(flagName, defaultValue)`. Fetched from Anthropic's backend (likely GrowthBook CDN at `cdn.growthbook.io`).
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `tengu_attribution_header` | `true` | Enables billing header |
+| `tengu_marble_anvil` | `false` | Enables context management beta |
+| `tengu_tool_pear` | checked via `IO()` | Enables structured outputs beta |
+| `tengu_scarf_coffee` | `false` | Enables tool examples beta |
+| `tengu_quiet_hollow` | `false` | Enables thinking redaction |
+| `tengu_penguins_off` | `null` | Fast mode control |
+| `tengu_amber_flint` | `true` | Agent teams |
+| `tengu_grey_wool` | `true` | Unknown |
+| `tengu_grey_step2` | varies | Unknown |
+| `tengu_coral_fern` | `false` | Team memory directories |
+| `tengu_herring_clock` | `false` | Team memory sync |
+| `tengu_paper_halyard` | `false` | Unknown |
+| `tengu_marble_sandcastle` | `false` | Fast mode native binary check |
+| `tengu_plan_mode_interview_phase` | `false` | Plan mode |
+| `tengu_pewter_ledger` | `null` | Unknown |
+| `tengu_mcp_elicitation` | `false` | MCP elicitation support |
+| `tengu_auto_mode_config` | `{}` | Auto mode allowed models |
+| `tengu_amber_quartz_disabled` | `false` | Unknown |
+| `tengu_passport_quail` | `false` | Memory extraction mode |
+| `tengu_swinburne_dune` | `false` | Memory mode variant |
+| `tengu_turtle_carbon` | `true` | Unknown |
+| `tengu_granite_whisper` | `false` | Repo text file size tracking |
+| `tengu_startup_perf` | - | Telemetry-only |
+| `tengu_fast_mode_fallback_triggered` | - | Telemetry-only |
+| `tengu_ripgrep_eagain_retry` | - | Telemetry-only |
+| `tengu_file_operation` | - | Telemetry-only |
+| `tengu_org_penguin_mode_fetch_failed` | - | Telemetry-only |
+
+## 10. API Endpoints
+
+| Purpose | URL |
+|---------|-----|
+| Messages | `https://api.anthropic.com/v1/messages` |
+| Client data | `<BASE_API_URL>/api/oauth/claude_cli/client_data` |
+| OAuth token | `https://console.anthropic.com/v1/oauth/token` |
+| API key creation | `https://api.anthropic.com/api/oauth/claude_cli/create_api_key` |
+| Metrics | `https://api.anthropic.com/api/claude_code/metrics` |
+| Feedback | `https://api.anthropic.com/api/claude_cli_feedback` |
+| Transcripts | `https://api.anthropic.com/api/claude_code_shared_session_transcripts` |
+| Feature flags | `https://cdn.growthbook.io` |
+| Binary dist | `https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases` |
+| Desktop (macOS) | `https://claude.ai/api/desktop/darwin/universal/dmg/latest/redirect` |
+| Desktop (Windows) | `https://claude.ai/api/desktop/win32/x64/exe/latest/redirect` |
+| MCP Proxy | `https://mcp-proxy.anthropic.com` |
+| Platform | `https://platform.claude.com` |
+| Staging API | `https://api-staging.anthropic.com` |
+
+## 11. Environment Variables
+
+Extracted from the binary. Variables that affect API behavior:
+
+| Variable | Effect |
+|----------|--------|
+| `ANTHROPIC_BASE_URL` | Override API base URL |
+| `ANTHROPIC_API_KEY` | API key auth |
+| `ANTHROPIC_BETAS` | Custom beta headers (comma-separated) |
+| `ANTHROPIC_CUSTOM_HEADERS` | Custom request headers |
+| `API_TIMEOUT_MS` | Request timeout (default: 600000) |
+| `CLAUDE_CODE_ENTRYPOINT` | User-agent entrypoint (default: `cli`) |
+| `CLAUDE_CODE_DISABLE_1M_CONTEXT` | Disable 1M context window |
+| `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` | Skip client_data fetch |
+| `CLAUDE_CODE_ATTRIBUTION_HEADER` | Set to `false` to disable billing header |
+| `CLAUDE_CODE_USE_BEDROCK` | Use Bedrock provider |
+| `CLAUDE_CODE_USE_VERTEX` | Use Vertex provider |
+| `CLAUDE_CODE_USE_FOUNDRY` | Use Foundry provider |
+| `CLAUDE_CODE_ADDITIONAL_PROTECTION` | Adds `x-anthropic-additional-protection: true` |
+| `CLAUDE_CODE_CONTAINER_ID` | Remote container ID header |
+| `CLAUDE_CODE_REMOTE_SESSION_ID` | Remote session ID header |
+| `CLAUDE_CODE_PROXY_RESOLVES_HOSTS` | Proxy configuration |
+| `CLAUDE_AGENT_SDK_VERSION` | Agent SDK version in user-agent |
+| `CLAUDE_AGENT_SDK_CLIENT_APP` | Client app name in user-agent |
+| `DISABLE_INTERLEAVED_THINKING` | Skip interleaved thinking beta |
+| `USE_API_CONTEXT_MANAGEMENT` | Force context management beta |
+| `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` | Proxy settings |
+
+## 12. Live Traffic Capture (via intercept proxy)
+
+Captured by routing `ANTHROPIC_BASE_URL=http://localhost:8877` through a Bun reverse proxy.
+
+### Haiku 4.5 request (`-p` mode)
+
+```
+POST /v1/messages
+anthropic-beta: oauth-2025-04-20,interleaved-thinking-2025-05-14,context-management-2025-06-27,prompt-caching-scope-2026-01-05,claude-code-20250219
+anthropic-version: 2023-06-01
+authorization: Bearer sk-ant-oat01-...
+content-type: application/json
+user-agent: claude-cli/2.1.80 (external, sdk-cli)
+x-app: cli
+```
+
+Body summary:
+```json
+{
+  "model": "claude-haiku-4-5",
+  "max_tokens": 32000,
+  "stream": true,
+  "system": [3 blocks, 27143 chars],
+  "messages": [1 message],
+  "tools": [26 tools],
+  "thinking": {"budget_tokens": 31999, "type": "enabled"}
+}
+```
+
+**Notable**: `claude-code-20250219` IS present despite haiku model — the `-p`/sdk-cli entrypoint may have different beta logic than interactive mode, or the haiku exclusion only applies to the interactive CLI path.
+
+**Notable**: `context-management-2025-06-27` is present — this means `tengu_marble_anvil` is `true` for this account or `USE_API_CONTEXT_MANAGEMENT` is set.
+
+**Notable**: `context-1m-2025-08-07` is NOT present — confirming it's opt-in only via `[1m]` suffix.
+
+### Second request (auto-compact)
+
+After the streaming response, the CLI sent a second non-streaming request with `max_tokens: 21333` and received a JSON response containing `context_management` field — confirming context management is active.
+
+## 13. bun-demincer Module Map
+
+Key modules for API/auth/beta behavior:
+
+| Module | Original Symbol | Purpose |
+|--------|----------------|---------|
+| `0743.js` | - | All beta flag string constants |
+| `0744.js` | `lc` | Platform detection (`U8()`), `ANTHROPIC_BASE_URL` validation |
+| `0747.js` | `OD` | `client_data` fetch, cache, `coral_reef_sonnet` gate |
+| `2016.js` | `dDq` | 1M context window logic, output token limits, model info cache |
+| `2018.js` | `bk` | **Beta header builder** (`FDq()`), bedrock filter, agent teams check |
+
+## 14. opencode-claude-auth Plugin Gap Analysis
+
+### What the plugin sends correctly
+- ✅ `oauth-2025-04-20`
+- ✅ `interleaved-thinking-2025-05-14`
+- ✅ `claude-code-20250219` (for non-haiku)
+- ✅ `context-1m-2025-08-07` (for 4.6+ models, with fallback retry)
+- ✅ System prompt identity prefix
+- ✅ `x-app: cli`
+- ✅ Billing header
+- ✅ User-agent fingerprint
+
+### What the plugin does NOT send (but the CLI does)
+- ❌ `prompt-caching-scope-2026-01-05` — always sent by CLI for firstParty
+- ❌ `context-management-2025-06-27` — sent when `tengu_marble_anvil` is enabled
+- ❌ `redact-thinking-2026-02-12` — sent when `tengu_quiet_hollow` is enabled
+- ❌ `structured-outputs-2025-12-15` — sent when `tengu_tool_pear` is enabled
+
+### What the plugin does differently
+- ⚠️ `context-1m-2025-08-07` — plugin sends it automatically for 4.6+ models; CLI only sends it with `[1m]` suffix
+- ⚠️ Version in user-agent — plugin uses `DEFAULT_CC_VERSION` which should track latest
+
+### Recommended changes
+1. **Add `prompt-caching-scope-2026-01-05`** — safe, always sent by CLI for firstParty
+2. **`context-1m` behavior** — current plugin approach (auto for 4.6+) is arguably better than CLI's (opt-in only), since 1M is now GA. Keep as-is.
+3. **Consider `context-management-2025-06-27`** — depends on whether OpenCode's own context management conflicts

--- a/external/CCH_ALGORITHM_NTT123.md
+++ b/external/CCH_ALGORITHM_NTT123.md
@@ -1,0 +1,153 @@
+# Claude Code CCH Algorithm (x-anthropic-billing-header)
+
+Source: https://gist.github.com/NTT123/579183bdd7e028880d06c8befae73b99
+Author: NTT123
+
+## Purpose
+
+The `x-anthropic-billing-header` is a computed system message required in every Claude Code API request. It serves as an authentication/integrity check that ties each request to the Claude Code client. Without it, OAuth tokens scoped to Claude Code will reject the request with:
+
+```
+This credential is only authorized for use with Claude Code and cannot be used for other API requests.
+```
+
+The header contains three fields:
+
+| Field | Example | Purpose |
+|-------|---------|---------|
+| `cc_version` | `2.1.37.0d9` | Client version + integrity hash (3 hex chars) |
+| `cc_entrypoint` | `cli` | How the request originated (cli, sdk, etc.) |
+| `cch` | `fa690` | Content hash of the user message (5 hex chars) |
+
+## Overall Algorithm
+
+```
+Input:  first user message text, CC_VERSION, BILLING_SALT
+Output: "x-anthropic-billing-header: cc_version=...; cc_entrypoint=...; cch=...;"
+```
+
+1. **Extract** the text content of the first user message.
+2. **Compute `cch`** -- a truncated SHA-256 hash of the full message text.
+3. **Compute the version hash suffix** -- a truncated SHA-256 hash of a salt, sampled characters from the message, and the version string.
+4. **Format** the billing header string.
+5. **Insert** it as the first system message, without `cache_control`.
+
+## Detailed Computation
+
+### Constants
+
+```
+CC_VERSION    = "2.1.37"
+BILLING_SALT  = "59cf53e54c78"   # from Claude Code's obfuscated source
+```
+
+### Step 1: Compute `cch` (Content Hash)
+
+The `cch` value is a straightforward truncated hash of the entire user message:
+
+```
+cch = SHA-256(message_text)[:5]    # first 5 hex characters
+```
+
+**Example:**
+
+```
+message_text = "hey"
+SHA-256("hey") = "fa690b82061edfd2852629aeba8a8977b57e40fcb77d1a7a28b26cba62591204"
+cch = "fa690"
+```
+
+### Step 2: Compute `cc_version` suffix (Version Integrity Hash)
+
+This hash binds the client version to sampled characters from the message, preventing trivial replay:
+
+```
+sampled = message_text[4] + message_text[7] + message_text[20]
+```
+
+If the message is shorter than the index, pad with `"0"`:
+
+```python
+sampled = "".join(
+    message_text[i] if i < len(message_text) else "0"
+    for i in (4, 7, 20)
+)
+```
+
+Then compute:
+
+```
+version_hash = SHA-256(BILLING_SALT + sampled + CC_VERSION)[:3]   # first 3 hex characters
+```
+
+The final version string is `CC_VERSION + "." + version_hash`, e.g. `2.1.37.0d9`.
+
+**Example:**
+
+```
+message_text = "hey"        (length 3, all indices out of bounds except none >= 3)
+sampled = "0" + "0" + "0"  = "000"
+SHA-256("59cf53e54c78" + "000" + "2.1.37") = "0d9..."
+version_hash = "0d9"
+cc_version = "2.1.37.0d9"
+```
+
+### Step 3: Format the header
+
+```
+x-anthropic-billing-header: cc_version=2.1.37.0d9; cc_entrypoint=cli; cch=fa690;
+```
+
+## Request Integration
+
+The billing header has specific placement requirements:
+
+1. It must be the **first entry** in the `system` messages array.
+2. It must **not** have `cache_control` (even if other system blocks do).
+3. It is recomputed per-request since it depends on the user message content.
+
+```json
+{
+  "system": [
+    {"type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.37.0d9; cc_entrypoint=cli; cch=fa690;"},
+    {"type": "text", "text": "You are Claude Code, Anthropic's official CLI for Claude."},
+    {"type": "text", "text": "...full system prompt..."}
+  ],
+  "messages": [{"role": "user", "content": "hey"}]
+}
+```
+
+## Reference Implementation
+
+```python
+import hashlib
+
+CC_VERSION = "2.1.37"
+_BILLING_SALT = "59cf53e54c78"
+
+def _sha256(s: str) -> str:
+    return hashlib.sha256(s.encode()).hexdigest()
+
+def compute_billing_header(message_text: str, entrypoint: str = "cli") -> str:
+    sampled = "".join(
+        message_text[i] if i < len(message_text) else "0"
+        for i in (4, 7, 20)
+    )
+    version_hash = _sha256(f"{_BILLING_SALT}{sampled}{CC_VERSION}")[:3]
+    cch = _sha256(message_text)[:5]
+    return (
+        f"x-anthropic-billing-header: "
+        f"cc_version={CC_VERSION}.{version_hash}; "
+        f"cc_entrypoint={entrypoint}; "
+        f"cch={cch};"
+    )
+```
+
+## Test Vectors
+
+| Message | `cc_version` | `cch` | `cc_entrypoint` |
+|---------|--------------|-------|-----------------|
+| `"hey"` | `2.1.37.0d9` | `fa690` | `cli` |
+| `""` (empty) | `2.1.37.xxx` | `e3b0c` | `cli` |
+
+The empty message case: `SHA-256("") = "e3b0c44298fc..."` so `cch = "e3b0c"`.

--- a/external/CLONE_REPORT.md
+++ b/external/CLONE_REPORT.md
@@ -1,0 +1,121 @@
+# Clone Report: Claude Code Reverse Engineering Resources
+
+## Status Summary
+
+### Repository 1: paoloanzn/free-code
+**Status:** ❌ FAILED - Repository is disabled
+- URL: https://github.com/paoloanzn/free-code
+- Error: "Repository 'paoloanzn/free-code' is disabled. Please ask the owner to check their account."
+- The repository appears to have been taken down or disabled by GitHub.
+
+### Repository 2: ssslomp CCH signing repo
+**Status:** ⚠️ NOT FOUND
+- Searched for repositories at https://github.com/ssslomp
+- Attempted common names: `cch`, `claude-code-cch`, `claude-code-reverse`
+- Result: No public repositories found under this username related to Claude Code or CCH signing
+- **Note:** The user may have been referring to someone else's work or a blog post/gist
+
+### Alternative: CCH Algorithm Documentation
+**Status:** ✅ SAVED
+- Found comprehensive CCH algorithm documentation by **NTT123**
+- Source: https://gist.github.com/NTT123/579183bdd7e028880d06c8befae73b99
+- Saved to: `CCH_ALGORITHM_NTT123.md`
+- This is the most detailed reverse-engineering writeup of the x-anthropic-billing-header
+
+## Successfully Cloned Repositories
+
+### 1. ghuntley/claude-code-source-code-deobfuscation
+**URL:** https://github.com/ghuntley/claude-code-source-code-deobfuscation
+**Stars:** 938 | **Forks:** 538
+**Description:** Cleanroom deobfuscation of the official Claude Code npm package
+
+**Notable Files:**
+- `README.md` - Overview and usage
+- `package.json` - Project configuration
+- `claude-code/` - Deobfuscated source code directory
+  - `src/` - TypeScript source files
+  - `scripts/` - Build and utility scripts
+  - `package.json` - Claude Code package config
+  - `tsconfig.json` - TypeScript configuration
+- `specs/` - Documentation directory
+  - `architecture.md` - System architecture
+  - `command_reference.md` - CLI command docs
+  - `features.md` - Feature documentation
+  - `overview.md` - High-level overview
+  - `error_handling.md` - Error handling patterns
+  - `performance.md` - Performance considerations
+
+### 2. hitmux/HitCC
+**URL:** https://github.com/hitmux/HitCC
+**Stars:** 629 | **Forks:** 222
+**Description:** Complete reverse-engineering documentation of Claude Code CLI v2.1.84 logic
+
+**Notable Files:**
+- `README.md` - Project overview and navigation guide
+- `README_zh.md` - Chinese version
+- `LICENSE` - CC BY 4.0 license
+- `docs/` - Comprehensive documentation (27,170 lines!)
+  - `00-overview/` - Scope, evidence, and conventions
+  - `01-runtime/` - CLI entry, session management, agent loop
+  - `02-execution/` - Tool execution, hooks, permissions, prompt assembly
+  - `03-ecosystem/` - MCP, Skill, Plugin, TUI, remote persistence
+  - `04-rewrite/` - Rewrite guidance and open questions
+  - `05-appendix/` - Glossary and evidence index
+- `recovery_tools/` - Python scripts for deobfuscation
+  - `extract_js_symbols.py`
+  - `format_bundle.py`
+  - `js_identifier_tools.py`
+  - `js_readability.py`
+
+**Key Features:**
+- Most comprehensive documentation set (27k+ lines)
+- Organized by runtime topics, not source tree
+- Includes confidence ratings and evidence tracking
+- Suitable for building alternative implementations
+
+### 3. Prajwalsrinvas/claude-code-reverse-engineering
+**URL:** https://github.com/Prajwalsrinvas/claude-code-reverse-engineering
+**Stars:** 3 | **Forks:** 1
+**Description:** Reverse engineering deep dives into Claude Code's features
+
+**Notable Files:**
+- `README.md` - Project overview
+- `deep-dives/` - Detailed analysis of specific features
+  - `compact/` - Compact mode analysis
+  - `insights/` - Various insights and findings
+  - `slash-commands/` - Slash command documentation
+  - `stats-and-context/` - Statistics and context tracking
+- `skill/` - Skill system documentation
+  - `README.md` - Skill system overview
+  - `REFERENCE.md` - API reference
+  - `SKILL.md` - Skill creation guide
+  - `scripts/` - Utility scripts
+
+## Additional Resource
+
+### CCH_ALGORITHM_NTT123.md
+Complete documentation of the `x-anthropic-billing-header` algorithm:
+- Purpose and authentication mechanism
+- Step-by-step computation algorithm
+- Python reference implementation
+- Test vectors and examples
+- Constants: `BILLING_SALT = "59cf53e54c78"`, version format: `2.1.37.xxx`
+
+## Recommendations
+
+1. **For CCH signing/billing header:** Use `CCH_ALGORITHM_NTT123.md` - most authoritative source
+2. **For comprehensive system understanding:** Start with `HitCC/docs/00-overview/00-index.md`
+3. **For clean TypeScript source:** Use `claude-code-source-code-deobfuscation/claude-code/src/`
+4. **For feature-specific deep dives:** Check `claude-code-reverse-engineering/deep-dives/`
+
+## Next Steps
+
+If you need the `paoloanzn/free-code` repository:
+- Check if there's a fork available
+- Contact the repository owner
+- Look for cached copies or mirrors
+
+If you need more info from ssslomp:
+- They may have published blog posts or gists instead of a full repo
+- Check platforms like: Medium, dev.to, personal blog
+- Search for "ssslomp claude code" on various platforms

--- a/notes/cch-signing-analysis.md
+++ b/notes/cch-signing-analysis.md
@@ -1,0 +1,50 @@
+# CCH Signing System — Complete Analysis
+
+## Timeline
+- **Mid-March 2026**: We identified cch= in billing header during bun binary RE (minzique/claude-code-re). Noted cch=00000 in npm builds, suspected fingerprinting, documented in API_REQUEST_MAP.md and research site
+- **Late March 2026**: Claude Code source leaked via npm .map file exposure
+- **April 1 2026**: ssslomp reverse-engineered the Zig-compiled signing algorithm; paoloanzn (free-code fork) integrated it
+- **April 1 2026**: NTT123 published clean algorithm documentation with test vectors (gist: github.com/NTT123/579183bdd7e028880d06c8befae73b99)
+
+## Algorithm (from NTT123's gist)
+- **BILLING_SALT** = '59cf53e54c78' (extracted from obfuscated Bun binary Zig code)
+- **cch** = SHA-256(first_user_message_text)[:5] (first 5 hex chars)
+- **version suffix**: sample chars at indices [4, 7, 20] from message (pad with '0'), then SHA-256(salt + sampled + version)[:3]
+- **Full format**: `x-anthropic-billing-header: cc_version=<ver>.<hash>; cc_entrypoint=<entrypoint>; cch=<hash>;`
+- **Injected as system[0].text**, NOT as HTTP header, no cache_control
+
+## Why cch=00000 Worked Before
+- npm distributed versions compute cch in JavaScript, which sends 00000
+- The compiled Bun binary has native Zig code that computes the real hash
+- Server-side enforcement was added later — initially the values weren't validated
+- Our behavioral tests (oauth-behavioral-tests.md) confirmed arbitrary values were accepted at the time
+
+## Server-Side Enforcement (Current)
+- **Wrong/missing cch → rejection**: 'Fast mode is currently available in research preview in Claude Code. It is not yet available via API.'
+- This gates access to fast mode (Opus 4.6 at 2.5x speed, $30/$150 per MTok)
+- **Gate chain**: cch validation → tengu_penguins_off → native binary check → provider check → org status
+
+## Fast Mode
+- **NOT a separate model** — same Opus 4.6, different billing/rate tier
+- **Toggle**: /fast command or fastMode: true in settings
+- **2.5x faster, 2x cost** ($30/$150 vs $15/$75 per MTok)
+- **First-party Anthropic API only** (no Bedrock, Vertex, Foundry)
+- **tengu_penguins_off**: nullable string flag, when set returns reason for disabling
+- Auto-fallback to standard Opus on quota exhaustion
+
+## Prompt Cache Breakage Bug (Issue #40652)
+- CLI does find-and-replace of cch= values across ALL message content per request
+- Since hash changes per-request, historical tool results containing cch= get mutated
+- This permanently invalidates prompt cache — cache_read drops, never recovers
+- Silently wastes ~50K tokens per turn in broken sessions
+- **Contagious**: investigating a broken session can infect the investigating session
+
+## References
+- NTT123 gist: https://gist.github.com/NTT123/579183bdd7e028880d06c8befae73b99
+- paoloanzn/free-code (DMCA'd): https://github.com/paoloanzn/free-code
+- Cache breakage: https://github.com/anthropics/claude-code/issues/40652
+- Our original research: site/src/pages/research.astro #billing section
+- Our behavioral tests: notes/oauth-behavioral-tests.md
+- Our API map: binaries/v2.1.80/API_REQUEST_MAP.md section 6
+- HitCC docs: external/hitmux/HitCC/docs/
+- Local algorithm doc: external/CCH_ALGORITHM_NTT123.md

--- a/notes/oauth-behavioral-tests.md
+++ b/notes/oauth-behavioral-tests.md
@@ -184,6 +184,8 @@ Prompt: `"What are you? What tools do you have? Be specific about your capabilit
 
 **Rule**: Must have both `cc_version=<any>;` and `cc_entrypoint=<any>;` in valid `key=value;` format. Values are not validated.
 
+> **Update (April 2026):** These tests were conducted before server-side cch= enforcement. As of late March 2026, the cch= value is now validated server-side. Incorrect values result in rejection: "Fast mode is currently available in research preview in Claude Code." The algorithm was reverse-engineered from the compiled Bun binary's Zig code — see `notes/cch-signing-analysis.md` for the full algorithm (SHA-256 based, salt: `59cf53e54c78`). Our finding that arbitrary values were accepted at the time of testing remains valid as historical documentation.
+
 ---
 
 ## Position Tests

--- a/notes/oauth-long-lived-tokens.md
+++ b/notes/oauth-long-lived-tokens.md
@@ -321,6 +321,8 @@ x-app: cli
 user-agent: claude-cli/2.1.81 (external, cli)
 x-anthropic-billing-header: cc_version=2.1.81.<model>; cc_entrypoint=cli; cch=00000;
 Content-Type: application/json
+
+**Note**: The `cch=00000` value shown above was from the npm/JS build. The compiled Bun binary computes a real SHA-256 based hash for request signing. See [cch-signing-analysis.md](cch-signing-analysis.md) for details.
 ```
 - Obtained via OAuth flow (uses your Claude Max/Pro subscription)
 - Billed against your subscription usage limits (not API credits)
@@ -462,7 +464,7 @@ The `Authorization: Bearer <token>` header must contain a valid, non-expired OAu
 | `x-anthropic-billing-header` (HTTP) | Present with same values as system prompt | ✓ not checked | Low — but absence is a signal |
 | Tool schemas | Claude Code's specific tool names | Partial — tool names visible in request | **High** — different tools = obvious |
 | System prompt structure | billing first, identity second, then content | ✓ order is flexible | Low |
-| `cch` field | `00000` (hardcoded in CLI) | ✓ any value | Low |
+| `cch` field | SHA-256 hash (Bun binary) / `00000` (npm build) | ✗ **server-enforced** | **High** — incorrect values cause request rejection |
 
 **Recommended approach for third-party tools:**
 ```

--- a/site/src/pages/research.astro
+++ b/site/src/pages/research.astro
@@ -112,8 +112,23 @@ Authorization: Bearer &lt;accessToken&gt;</code></pre>
   <section class="card" id="billing">
     <h2>Billing attribution</h2>
     <p>Here's a weird one. The billing header isn't actually sent as an HTTP header. It's injected as plain text into the first system prompt block:</p>
-    <pre><code>system[0].text = "x-anthropic-billing-header: cc_version=2.1.80.a46; cc_entrypoint=sdk-cli; cch=00000;"</code></pre>
-    <p>The format: <code>cc_version=&lt;ver&gt;.&lt;modelId&gt;; cc_entrypoint=&lt;entrypoint&gt;; cch=00000; cc_workload=&lt;workload&gt;;</code></p>
+    <pre><code>system[0].text = "x-anthropic-billing-header: cc_version=2.1.80.a46; cc_entrypoint=sdk-cli; cch=a1b2c; cc_version_suffix=d3e4f;"</code></pre>
+    
+    <h3>The cch= field is a computed hash</h3>
+    <p>The <code>cch=</code> field is <strong>not</strong> a static placeholder. It's a SHA-256 hash of the first user message:</p>
+    <pre><code>cch = SHA-256(first_user_message_text).substring(0, 5)</code></pre>
+    <p>The <code>cc_version_suffix=</code> uses a similar algorithm: hash a salt concatenated with sampled characters from the same input.</p>
+    
+    <h3>npm vs. Bun implementation</h3>
+    <p>The npm/JavaScript builds originally sent <code>cch=00000</code> (which is what we initially documented). The compiled Bun binary computes real hash values via native Zig code in the crypto module.</p>
+    
+    <h3>Server-side enforcement</h3>
+    <p>The API validates the <code>cch=</code> value. Requests with incorrect hashes are rejected from fast mode. This appears to be an anti-abuse mechanism to detect tampered or replayed requests.</p>
+    
+    <h3>Prompt cache breakage (issue #40652)</h3>
+    <p>The CLI's implementation has a critical bug: it performs find-and-replace of <code>cch=</code> across <strong>all message content</strong>, including historical tool results in the conversation. This mutates cached content, permanently breaking prompt caching for the entire session. Once the hash changes, every prior cache key is invalidated.</p>
+    
+    <p>The full format: <code>cc_version=&lt;ver&gt;.&lt;modelId&gt;; cc_entrypoint=&lt;entrypoint&gt;; cch=&lt;hash&gt;; cc_version_suffix=&lt;hash&gt;; cc_workload=&lt;workload&gt;;</code></p>
     <p>Gated by <code>tengu_attribution_header</code> (default: true). Disable with <code>CLAUDE_CODE_ATTRIBUTION_HEADER=false</code>.</p>
   </section>
 
@@ -128,7 +143,7 @@ Authorization: Bearer &lt;accessToken&gt;</code></pre>
       <div class="ft-row"><code>tengu_quiet_hollow</code><span>Enables thinking redaction</span></div>
       <div class="ft-row"><code>tengu_amber_flint</code><span>Agent teams (default: true)</span></div>
       <div class="ft-row"><code>tengu_attribution_header</code><span>Billing header (default: true)</span></div>
-      <div class="ft-row"><code>tengu_penguins_off</code><span>Fast mode control</span></div>
+      <div class="ft-row"><code>tengu_penguins_off</code><span>Fast mode gate — nullable string, non-null value disables fast mode with reason</span></div>
       <div class="ft-row"><code>tengu_coral_fern</code><span>Team memory directories</span></div>
       <div class="ft-row"><code>tengu_herring_clock</code><span>Team memory sync</span></div>
       <div class="ft-row"><code>tengu_mcp_elicitation</code><span>MCP elicitation support</span></div>
@@ -250,7 +265,7 @@ Authorization: Bearer &lt;accessToken&gt;</code></pre>
 
   <footer class="pg-foot">
     <a href={`${base}/`}>← Version monitor</a>
-    <span class="pg-note">Research by <a href="https://github.com/minzique">@minzique</a> · Binary analysis of v2.1.80–2.1.81. No Anthropic docs were used as a source.</span>
+    <span class="pg-note">Research by <a href="https://github.com/minzique">@minzique</a> · Binary analysis of v2.1.80–2.1.84. CCH signing algorithm reversed April 2026.</span>
   </footer>
 </Base>
 


### PR DESCRIPTION
## Summary

Adds comprehensive documentation of the `cch=` request signing system and fast mode mechanics, based on community reverse engineering (NTT123's algorithm gist, ssslomp/paoloanzn's work) cross-referenced with our existing research.

### New files
- `notes/cch-signing-analysis.md` — definitive reference: timeline, algorithm (SHA-256, salt `59cf53e54c78`), fast mode, cache breakage bug
- `external/CCH_ALGORITHM_NTT123.md` — NTT123's algorithm doc with test vectors
- `external/CLONE_REPORT.md` — inventory of cloned external RE repos

### Updated files
- `site/src/pages/research.astro` — billing section rewritten with signing algorithm, enforcement details, cache breakage bug; `tengu_penguins_off` description expanded; footer updated
- `notes/oauth-behavioral-tests.md` — added enforcement update note to billing tests
- `notes/oauth-long-lived-tokens.md` — updated cch=00000 context, fingerprinting risk Low→High
- `binaries/v2.1.80/API_REQUEST_MAP.md` — added CCH Signing subsection

### Key findings
- `cch = SHA-256(first_user_message)[:5]` with salt `59cf53e54c78`
- npm builds send `cch=00000` (JS placeholder); Bun binary computes via native Zig
- Server-side enforcement added late March 2026 — wrong cch rejects with fast mode error
- Fast mode = same Opus 4.6 at 2.5x speed / 2x cost, gated by cch + `tengu_penguins_off`
- Cache breakage bug: CLI find-and-replace of cch= across all messages mutates history (anthropics/claude-code#40652)