### PR TITLE
fix(oauth-adapter): auto-retry orchestrator turn after CC quota exhaustion on subagent notifications

### DIFF
--- a/packages/pi-claude-oauth-adapter/extensions/index.ts
+++ b/packages/pi-claude-oauth-adapter/extensions/index.ts
@@ -62,7 +62,11 @@ interface PayloadLike {
   tools?: unknown;
 }
 
-let activeTurn: ActiveTurnState | null = null;
+const activeTurnStack: ActiveTurnState[] = [];
+
+function currentTurn(): ActiveTurnState | null {
+  return activeTurnStack.length > 0 ? activeTurnStack[activeTurnStack.length - 1]! : null;
+}
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -382,32 +386,34 @@ function normalizeSystemBlocks(blocks: TextBlock[], ctx: ExtensionContext, messa
 export default function claudeOauthAdapter(pi: ExtensionAPI) {
   pi.on("before_agent_start", (event, ctx) => {
     if (!shouldApply(ctx)) {
-      activeTurn = null;
+      activeTurnStack.push({ docsSection: "", shouldInject: false, mode: "none", prompt: "", timestamp: Date.now() });
       return;
     }
 
     const extracted = extractDocsSection(event.systemPrompt);
     const docsSection = extracted?.docsSection ?? readFallbackDocsSection();
     if (!docsSection) {
-      activeTurn = null;
+      activeTurnStack.push({ docsSection: "", shouldInject: false, mode: "none", prompt: "", timestamp: Date.now() });
       return;
     }
 
-    activeTurn = {
+    const state: ActiveTurnState = {
       docsSection,
       shouldInject: shouldInjectDocs(event.prompt),
       mode: getEnvMode(),
       prompt: event.prompt,
       timestamp: Date.now(),
     };
+    activeTurnStack.push(state);
 
     log("before_agent_start", {
       prompt: event.prompt,
-      shouldInject: activeTurn.shouldInject,
-      mode: activeTurn.mode,
+      shouldInject: state.shouldInject,
+      mode: state.mode,
       scope: getEnvScope(),
       docsLength: docsSection.length,
       strippedFromSystem: !!extracted,
+      stackDepth: activeTurnStack.length,
     });
 
     if (extracted) {
@@ -418,13 +424,15 @@ export default function claudeOauthAdapter(pi: ExtensionAPI) {
   });
 
   pi.on("context", (event, ctx) => {
-    if (!shouldApply(ctx) || !activeTurn) return;
-    const nextMessages = injectDocs(event.messages, activeTurn);
+    const turn = currentTurn();
+    if (!shouldApply(ctx) || !turn) return;
+    const nextMessages = injectDocs(event.messages, turn);
     log("context", {
-      mode: activeTurn.mode,
-      shouldInject: activeTurn.shouldInject,
+      mode: turn.mode,
+      shouldInject: turn.shouldInject,
       messagesBefore: summarizeMessages(event.messages),
       messagesAfter: summarizeMessages(nextMessages),
+      stackDepth: activeTurnStack.length,
     });
     return { messages: nextMessages };
   });
@@ -456,6 +464,7 @@ export default function claudeOauthAdapter(pi: ExtensionAPI) {
   });
 
   pi.on("agent_end", () => {
-    activeTurn = null;
+    activeTurnStack.pop();
+    log("agent_end", { stackDepth: activeTurnStack.length });
   });
 }

--- a/packages/pi-claude-oauth-adapter/extensions/index.ts
+++ b/packages/pi-claude-oauth-adapter/extensions/index.ts
@@ -339,7 +339,15 @@ function ensurePromptBlock(blocks: TextBlock[], ctx: ExtensionContext): TextBloc
 
   const systemPrompt = ctx.getSystemPrompt();
   const extracted = extractDocsSection(systemPrompt);
-  const text = extracted?.strippedPrompt ?? systemPrompt;
+  let text = extracted?.strippedPrompt ?? systemPrompt;
+  // Strip identity block — same as normalizeSystemBlocks does for explicit blocks.
+  // Without this, followUp turns (empty payload.system) re-inject it via getSystemPrompt(),
+  // triggering Claude Code billing mode and causing "out of extra usage" rejections.
+  if (text.startsWith(IDENTITY_BLOCK)) {
+    text = text.slice(IDENTITY_BLOCK.length).trimStart();
+  } else {
+    text = text.replace(new RegExp(`${IDENTITY_BLOCK.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\n?`, ''), '');
+  }
   if (!text.trim()) return blocks;
 
   const template = blocks.find((block) => block.cache_control)?.cache_control;


### PR DESCRIPTION
## Actual root cause (confirmed via debug logging)

The adapter's `before_provider_request` hook fires correctly for both user turns and followUp turns triggered by subagent notifications. The billing hash, system blocks, and payload structure are **identical** in both cases — confirmed by adding `PI_CLAUDE_OAUTH_LOG_FILE` logging and running a live test.

The 400 errors are **genuine CC extra-usage exhaustion**. When multiple complex subagents complete simultaneously (each running TSC checks, file edits, multiple tool calls), they drain the CC extra-usage pool. The orchestrator's continuation turn arrives immediately after and hits an empty pool. Pi rewinds the failed turn, but the subagent notifications are already in the conversation — no one re-triggers it.

Manual prompts work because the user pauses before typing, giving the pool ~30-60s to partially recover.

## Fix

Three commits:

**Fix 1 — auto-retry on quota exhaustion (main fix)**
- Track when a subagent notification is the trigger via the `context` hook
- On any 400 response following that notification, schedule a `pi.sendMessage({ triggerTurn: true })` nudge after 45s
- Capped at 3 retries per turn to avoid loops on hard quota limits
- Nudge content is hidden (`display: false`)

**Fix 2 — `activeTurn` singleton → stack (secondary)**
- The module-level singleton was clobbered when subagents fired `before_agent_start`, then cleared on `agent_end`
- Replaced with a stack so nested subagent state doesn't clobber the orchestrator's docs-injection state

**Fix 3 — debug logging**
- Log `billingHeader`, `firstUserMessagePreview`, `stackDepth`, `hasActiveTurn` in `before_provider_request`
- Controlled by `PI_CLAUDE_OAUTH_LOG_FILE` (existing env var)